### PR TITLE
feat: wire all API handlers in server entry point

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -13,11 +13,13 @@ import (
 	"time"
 
 	"github.com/kiranshivaraju/loghunter/internal/ai"
+	"github.com/kiranshivaraju/loghunter/internal/analysis"
 	"github.com/kiranshivaraju/loghunter/internal/api"
+	"github.com/kiranshivaraju/loghunter/internal/api/handler"
 	mw "github.com/kiranshivaraju/loghunter/internal/api/middleware"
-	"github.com/kiranshivaraju/loghunter/internal/api/response"
-	"github.com/kiranshivaraju/loghunter/internal/cache"
+"github.com/kiranshivaraju/loghunter/internal/cache"
 	"github.com/kiranshivaraju/loghunter/internal/config"
+	"github.com/kiranshivaraju/loghunter/internal/loki"
 	"github.com/kiranshivaraju/loghunter/internal/store"
 )
 
@@ -79,10 +81,25 @@ func run() error {
 	}
 	slog.Info("AI provider initialized", "provider", aiProvider.Name())
 
-	// 6. Create store
+	// 6. Create Loki client
+	lokiClient := loki.NewHTTPClient(
+		cfg.Loki.BaseURL,
+		cfg.Loki.Username,
+		cfg.Loki.Password,
+		cfg.Loki.OrgID,
+		cfg.Loki.Timeout,
+	)
+	slog.Info("loki client initialized", "url", cfg.Loki.BaseURL)
+
+	// 7. Create store
 	pgStore := store.NewPostgresStore(pool)
 
-	// 7. Build router with dependencies
+	// 8. Create services
+	analysisSvc := ai.NewAnalysisService(aiProvider, lokiClient, pgStore, redisCache, cfg.AI.InferenceTimeout)
+	searchSvc := analysis.NewSearchService(lokiClient, pgStore, redisCache)
+	summarizeAdapter := &summarizeAdapterSvc{svc: analysisSvc}
+
+	// 9. Build router with dependencies
 	auth := mw.NewAuth(pgStore)
 	rateLimit := mw.NewRateLimit(redisCache, 60)
 
@@ -90,13 +107,21 @@ func run() error {
 		Auth:      auth,
 		RateLimit: rateLimit,
 
-		HealthHandler: healthHandler(pgStore, redisCache),
-		// Remaining handlers will be wired as they are implemented
+		HealthHandler:    handler.NewHealthHandler(pgStore, redisCache, lokiClient, aiProvider),
+		AnalyzeHandler:   handler.NewAnalyzeHandler(pgStore, analysisSvc),
+		PollJobHandler:   handler.NewPollJobHandler(pgStore, redisCache),
+		ListClusters:     handler.NewListClustersHandler(pgStore),
+		GetCluster:       handler.NewGetClusterHandler(pgStore),
+		SummarizeHandler: handler.NewSummarizeHandler(summarizeAdapter),
+		SearchHandler:    handler.NewSearchHandler(searchSvc),
+		CreateKeyHandler: handler.NewCreateKeyHandler(pgStore),
+		ListKeysHandler:  handler.NewListKeysHandler(pgStore),
+		RevokeKeyHandler: handler.NewRevokeKeyHandler(pgStore),
 	}
 
 	router := api.NewRouter(deps)
 
-	// 8. Start HTTP server
+	// 10. Start HTTP server
 	addr := fmt.Sprintf(":%d", cfg.Server.Port)
 	srv := &http.Server{
 		Addr:         addr,
@@ -136,31 +161,30 @@ func run() error {
 	return nil
 }
 
-// healthHandler checks database and cache connectivity.
-func healthHandler(s store.Store, c cache.Cache) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		checks := map[string]string{
-			"database": "ok",
-			"cache":    "ok",
-		}
+// summarizeAdapterSvc adapts ai.AnalysisService to the handler.Summarizer interface.
+// The handler interface doesn't pass context, so the adapter uses context.Background().
+type summarizeAdapterSvc struct {
+	svc *ai.AnalysisService
+}
 
-		if err := s.Ping(r.Context()); err != nil {
-			checks["database"] = "degraded"
-		}
-		if err := c.Ping(r.Context()); err != nil {
-			checks["cache"] = "degraded"
-		}
-
-		degraded := checks["database"] != "ok" || checks["cache"] != "ok"
-		if degraded {
-			response.Error(w, http.StatusServiceUnavailable, "DEGRADED",
-				"One or more services degraded", checks)
-			return
-		}
-
-		response.JSON(w, map[string]any{
-			"status":   "ok",
-			"services": checks,
-		})
+func (a *summarizeAdapterSvc) Summarize(params handler.SummarizeParams) (*handler.SummarizeResult, error) {
+	result, err := a.svc.Summarize(context.Background(), ai.SummarizeParams{
+		TenantID:  params.TenantID,
+		Service:   params.Service,
+		Namespace: params.Namespace,
+		Start:     params.Start,
+		End:       params.End,
+		MaxLines:  params.MaxLines,
+	})
+	if err != nil {
+		return nil, err
 	}
+	return &handler.SummarizeResult{
+		Summary:       result.Summary,
+		LinesAnalyzed: result.LinesAnalyzed,
+		From:          result.From,
+		To:            result.To,
+		Provider:      result.Provider,
+		Model:         result.Model,
+	}, nil
 }

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/kiranshivaraju/loghunter/internal/api/handler"
 	"github.com/kiranshivaraju/loghunter/internal/cache"
 	"github.com/kiranshivaraju/loghunter/internal/store"
 	"github.com/kiranshivaraju/loghunter/pkg/models"
@@ -88,10 +89,24 @@ func (c *testCache) IncrWithExpiry(_ context.Context, _ string, _ time.Duration)
 
 var _ cache.Cache = (*testCache)(nil)
 
+// ─── mock loki & AI for health handler ──────────────────────────────────────
+
+type testLoki struct {
+	readyErr error
+}
+
+func (l *testLoki) Ready(_ context.Context) error { return l.readyErr }
+
+type testAI struct {
+	name string
+}
+
+func (a *testAI) Name() string { return a.name }
+
 // ─── health handler tests ───────────────────────────────────────────────────
 
 func TestHealthHandler_AllOK(t *testing.T) {
-	h := healthHandler(&testStore{}, &testCache{})
+	h := handler.NewHealthHandler(&testStore{}, &testCache{}, &testLoki{}, &testAI{name: "ollama"})
 
 	req := httptest.NewRequest("GET", "/api/v1/health", nil)
 	w := httptest.NewRecorder()
@@ -103,13 +118,18 @@ func TestHealthHandler_AllOK(t *testing.T) {
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
 	data := body["data"].(map[string]any)
 	assert.Equal(t, "ok", data["status"])
-	services := data["services"].(map[string]any)
-	assert.Equal(t, "ok", services["database"])
-	assert.Equal(t, "ok", services["cache"])
+	checks := data["checks"].(map[string]any)
+	assert.Equal(t, "ok", checks["database"])
+	assert.Equal(t, "ok", checks["redis"])
 }
 
 func TestHealthHandler_DatabaseDegraded(t *testing.T) {
-	h := healthHandler(&testStore{pingErr: errors.New("connection refused")}, &testCache{})
+	h := handler.NewHealthHandler(
+		&testStore{pingErr: errors.New("connection refused")},
+		&testCache{},
+		&testLoki{},
+		&testAI{name: "ollama"},
+	)
 
 	req := httptest.NewRequest("GET", "/api/v1/health", nil)
 	w := httptest.NewRecorder()
@@ -119,12 +139,17 @@ func TestHealthHandler_DatabaseDegraded(t *testing.T) {
 
 	var body map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
-	errObj := body["error"].(map[string]any)
-	assert.Equal(t, "DEGRADED", errObj["code"])
+	data := body["data"].(map[string]any)
+	assert.Equal(t, "degraded", data["status"])
 }
 
 func TestHealthHandler_CacheDegraded(t *testing.T) {
-	h := healthHandler(&testStore{}, &testCache{pingErr: errors.New("redis down")})
+	h := handler.NewHealthHandler(
+		&testStore{},
+		&testCache{pingErr: errors.New("redis down")},
+		&testLoki{},
+		&testAI{name: "ollama"},
+	)
 
 	req := httptest.NewRequest("GET", "/api/v1/health", nil)
 	w := httptest.NewRecorder()
@@ -134,9 +159,11 @@ func TestHealthHandler_CacheDegraded(t *testing.T) {
 }
 
 func TestHealthHandler_BothDegraded(t *testing.T) {
-	h := healthHandler(
+	h := handler.NewHealthHandler(
 		&testStore{pingErr: errors.New("db down")},
 		&testCache{pingErr: errors.New("redis down")},
+		&testLoki{},
+		&testAI{name: "ollama"},
 	)
 
 	req := httptest.NewRequest("GET", "/api/v1/health", nil)


### PR DESCRIPTION
## Summary

Wires all 10 API handler endpoints in the server main entry point. Previously only the health check was connected — all other routes returned 501 Not Implemented.

## Changes

- `cmd/server/main.go` — Create Loki client, AnalysisService, SearchService; wire all handler constructors into Dependencies struct; add summarize adapter
- `cmd/server/main_test.go` — Update health handler tests to use `handler.NewHealthHandler` with full dependency mocks

## Endpoints Now Functional

- GET /api/v1/health
- POST /api/v1/analyze
- GET /api/v1/analyze/{jobID}
- GET /api/v1/clusters
- GET /api/v1/clusters/{clusterID}
- POST /api/v1/search
- POST /api/v1/summarize
- POST /api/v1/admin/keys
- GET /api/v1/admin/keys
- DELETE /api/v1/admin/keys/{keyID}

## Testing

All 18 test packages pass. Server builds cleanly.