### PR TITLE
feat: Watcher — proactive log monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,58 @@ AI_PROVIDER=anthropic
 ANTHROPIC_API_KEY=sk-ant-...
 ```
 
+## Watcher — Proactive Log Monitoring
+
+The Watcher is a background loop that continuously monitors your services for errors — so you don't have to go hunting for them manually.
+
+**How it works:**
+
+1. Every 60 seconds, the Watcher queries Loki for recent error/warn logs across your services
+2. Groups identical errors into clusters using fingerprinting (normalizes timestamps, UUIDs, hex addresses, then hashes)
+3. Detects **new** error clusters (never seen before) and **spikes** (error count jumped 3x+)
+4. Automatically triggers AI root cause analysis on new/spiking clusters
+5. Results are available via `GET /api/v1/watcher/status` — by the time you check, the answer is already there
+
+**Enable it:**
+
+```bash
+WATCHER_ENABLED=true
+WATCHER_INTERVAL_SECS=30              # poll every 30s (default: 60)
+WATCHER_SERVICES=payment-service,auth-service  # or omit to auto-discover from Loki
+WATCHER_AUTO_ANALYZE=true             # auto-trigger AI analysis (default: true)
+WATCHER_SPIKE_THRESHOLD=3.0           # 3x count increase = spike (default: 3.0)
+```
+
+**All Watcher config:**
+
+| Env Var | Default | Description |
+|---------|---------|-------------|
+| `WATCHER_ENABLED` | `false` | Enable the background watcher |
+| `WATCHER_INTERVAL_SECS` | `60` | Seconds between poll cycles |
+| `WATCHER_LOOKBACK_SECS` | `120` | How far back each poll looks |
+| `WATCHER_SERVICES` | *(empty)* | Comma-separated service list, or empty for auto-discovery |
+| `WATCHER_NAMESPACE` | `default` | Namespace filter for Loki queries |
+| `WATCHER_AUTO_ANALYZE` | `true` | Auto-trigger AI analysis on findings |
+| `WATCHER_SPIKE_THRESHOLD` | `3.0` | Count ratio that constitutes a spike |
+| `WATCHER_MAX_SERVICES` | `50` | Cap on auto-discovered services |
+| `WATCHER_LOGS_LIMIT` | `2000` | Max log lines per service per poll |
+
+## API Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/v1/health` | Health check (public) |
+| `GET` | `/api/v1/watcher/status` | Watcher status and recent findings |
+| `POST` | `/api/v1/search` | Search logs by keyword, service, time range |
+| `GET` | `/api/v1/clusters` | List error clusters |
+| `GET` | `/api/v1/clusters/{id}` | Get cluster details |
+| `POST` | `/api/v1/analyze` | Trigger AI analysis on a cluster |
+| `GET` | `/api/v1/analyze/{jobID}` | Poll analysis job status |
+| `POST` | `/api/v1/summarize` | AI-powered log summary |
+| `POST` | `/api/v1/admin/keys` | Create API key (admin) |
+| `GET` | `/api/v1/admin/keys` | List API keys (admin) |
+| `DELETE` | `/api/v1/admin/keys/{id}` | Revoke API key (admin) |
+
 ## Project Structure
 
 ```
@@ -108,22 +160,14 @@ ANTHROPIC_API_KEY=sk-ant-...
 │   │   ├── anthropic/
 │   │   └── mock/       # Test mock provider
 │   ├── analysis/       # Error clustering and detection
-│   ├── anomaly/        # Anomaly detection and baselines
+│   ├── watcher/        # Proactive log monitoring background loop
 │   ├── store/          # PostgreSQL data access layer
 │   ├── cache/          # Redis cache layer
 │   └── config/         # Configuration loading
 ├── pkg/
 │   ├── models/         # Shared data models (AIProvider interface, etc.)
-│   ├── logql/          # Shared LogQL utilities
-│   └── notify/         # Notification senders
-├── alloy/              # Grafana Alloy extension component
+│   └── logql/          # Shared LogQL utilities
 ├── migrations/         # SQL migration files
-├── grafana-plugin/     # Grafana plugin (TypeScript/React)
-├── tests/
-│   ├── unit/           # Unit tests
-│   ├── contract/       # API contract tests
-│   ├── integration/    # Integration tests
-│   └── fixtures/       # Test data fixtures
 ├── product/            # Product documentation (PRD, tech docs)
 ├── sprints/            # Sprint documentation
 └── .prodkit/           # ProdKit framework config

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -17,10 +17,11 @@ import (
 	"github.com/kiranshivaraju/loghunter/internal/api"
 	"github.com/kiranshivaraju/loghunter/internal/api/handler"
 	mw "github.com/kiranshivaraju/loghunter/internal/api/middleware"
-"github.com/kiranshivaraju/loghunter/internal/cache"
+	"github.com/kiranshivaraju/loghunter/internal/cache"
 	"github.com/kiranshivaraju/loghunter/internal/config"
 	"github.com/kiranshivaraju/loghunter/internal/loki"
 	"github.com/kiranshivaraju/loghunter/internal/store"
+	"github.com/kiranshivaraju/loghunter/internal/watcher"
 )
 
 const shutdownTimeout = 30 * time.Second
@@ -99,7 +100,17 @@ func run() error {
 	searchSvc := analysis.NewSearchService(lokiClient, pgStore, redisCache)
 	summarizeAdapter := &summarizeAdapterSvc{svc: analysisSvc}
 
-	// 9. Build router with dependencies
+	// 9. Create watcher
+	defaultTenant, err := pgStore.GetDefaultTenant(ctx)
+	if err != nil {
+		return fmt.Errorf("get default tenant: %w", err)
+	}
+
+	w := watcher.New(cfg.Watcher, lokiClient, pgStore, analysisSvc, redisCache, defaultTenant)
+	go w.Run(ctx)
+	watcherStatusAdapter := &watcherStatusAdapterSvc{w: w}
+
+	// 10. Build router with dependencies
 	auth := mw.NewAuth(pgStore)
 	rateLimit := mw.NewRateLimit(redisCache, 60)
 
@@ -107,8 +118,9 @@ func run() error {
 		Auth:      auth,
 		RateLimit: rateLimit,
 
-		HealthHandler:    handler.NewHealthHandler(pgStore, redisCache, lokiClient, aiProvider),
-		AnalyzeHandler:   handler.NewAnalyzeHandler(pgStore, analysisSvc),
+		HealthHandler:        handler.NewHealthHandler(pgStore, redisCache, lokiClient, aiProvider),
+		WatcherStatusHandler: handler.NewWatcherStatusHandler(watcherStatusAdapter),
+		AnalyzeHandler:       handler.NewAnalyzeHandler(pgStore, analysisSvc),
 		PollJobHandler:   handler.NewPollJobHandler(pgStore, redisCache),
 		ListClusters:     handler.NewListClustersHandler(pgStore),
 		GetCluster:       handler.NewGetClusterHandler(pgStore),
@@ -121,7 +133,7 @@ func run() error {
 
 	router := api.NewRouter(deps)
 
-	// 10. Start HTTP server
+	// 11. Start HTTP server
 	addr := fmt.Sprintf(":%d", cfg.Server.Port)
 	srv := &http.Server{
 		Addr:         addr,
@@ -186,5 +198,25 @@ func (a *summarizeAdapterSvc) Summarize(params handler.SummarizeParams) (*handle
 		To:            result.To,
 		Provider:      result.Provider,
 		Model:         result.Model,
+	}, nil
+}
+
+// watcherStatusAdapterSvc adapts watcher.Watcher to the handler.WatcherStatusProvider interface.
+type watcherStatusAdapterSvc struct {
+	w *watcher.Watcher
+}
+
+func (a *watcherStatusAdapterSvc) WatcherStatus(ctx context.Context) (handler.WatcherStatus, error) {
+	s, err := a.w.Status(ctx)
+	if err != nil {
+		return handler.WatcherStatus{}, err
+	}
+	return handler.WatcherStatus{
+		Enabled:         s.Enabled,
+		Running:         s.Running,
+		LastPollAt:      s.LastPollAt,
+		NextPollAt:      s.NextPollAt,
+		ServicesWatched: s.ServicesWatched,
+		RecentFindings:  s.RecentFindings,
 	}, nil
 }

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -64,6 +64,15 @@ func (s *testStore) GetJob(_ context.Context, _ uuid.UUID, _ uuid.UUID) (*models
 func (s *testStore) UpdateJobStatus(_ context.Context, _ uuid.UUID, _ string, _ ...store.JobUpdateOption) error {
 	return nil
 }
+func (s *testStore) UpsertErrorClusterFull(_ context.Context, _ *models.ErrorCluster) (store.UpsertResult, error) {
+	return store.UpsertResult{}, nil
+}
+func (s *testStore) CreateWatcherFinding(_ context.Context, _ *models.WatcherFinding) error {
+	return nil
+}
+func (s *testStore) ListWatcherFindings(_ context.Context, _ uuid.UUID, _ int) ([]*models.WatcherFinding, error) {
+	return nil, nil
+}
 
 var _ store.Store = (*testStore)(nil)
 

--- a/internal/ai/service_test.go
+++ b/internal/ai/service_test.go
@@ -49,6 +49,13 @@ func (s *mockStore) GetClustersByFingerprints(_ context.Context, _ uuid.UUID, _ 
 func (s *mockStore) GetAnalysisResultByJobID(_ context.Context, _ uuid.UUID) (*models.AnalysisResult, error) { return nil, nil }
 func (s *mockStore) GetAnalysisResultByClusterID(_ context.Context, _ uuid.UUID) (*models.AnalysisResult, error) { return nil, nil }
 func (s *mockStore) GetJob(_ context.Context, _ uuid.UUID, _ uuid.UUID) (*models.Job, error) { return nil, nil }
+func (s *mockStore) UpsertErrorClusterFull(_ context.Context, _ *models.ErrorCluster) (store.UpsertResult, error) {
+	return store.UpsertResult{}, nil
+}
+func (s *mockStore) CreateWatcherFinding(_ context.Context, _ *models.WatcherFinding) error { return nil }
+func (s *mockStore) ListWatcherFindings(_ context.Context, _ uuid.UUID, _ int) ([]*models.WatcherFinding, error) {
+	return nil, nil
+}
 
 func (s *mockStore) CreateJob(_ context.Context, job *models.Job) error {
 	if s.createJobErr != nil {

--- a/internal/analysis/search_test.go
+++ b/internal/analysis/search_test.go
@@ -76,6 +76,15 @@ func (m *mockSearchStore) ListAPIKeys(_ context.Context, _ uuid.UUID) ([]*models
 func (m *mockSearchStore) RevokeAPIKey(_ context.Context, _ uuid.UUID, _ uuid.UUID) error {
 	return nil
 }
+func (m *mockSearchStore) UpsertErrorClusterFull(_ context.Context, _ *models.ErrorCluster) (store.UpsertResult, error) {
+	return store.UpsertResult{}, nil
+}
+func (m *mockSearchStore) CreateWatcherFinding(_ context.Context, _ *models.WatcherFinding) error {
+	return nil
+}
+func (m *mockSearchStore) ListWatcherFindings(_ context.Context, _ uuid.UUID, _ int) ([]*models.WatcherFinding, error) {
+	return nil, nil
+}
 
 // --- mock cache ---
 

--- a/internal/api/handler/contract_test.go
+++ b/internal/api/handler/contract_test.go
@@ -194,6 +194,15 @@ func (s *mockStore) UpdateJobStatus(_ context.Context, id uuid.UUID, status stri
 	}
 	return store.ErrNotFound
 }
+func (s *mockStore) UpsertErrorClusterFull(_ context.Context, _ *models.ErrorCluster) (store.UpsertResult, error) {
+	return store.UpsertResult{}, nil
+}
+func (s *mockStore) CreateWatcherFinding(_ context.Context, _ *models.WatcherFinding) error {
+	return nil
+}
+func (s *mockStore) ListWatcherFindings(_ context.Context, _ uuid.UUID, _ int) ([]*models.WatcherFinding, error) {
+	return nil, nil
+}
 
 var _ store.Store = (*mockStore)(nil)
 

--- a/internal/api/handler/watcher.go
+++ b/internal/api/handler/watcher.go
@@ -1,0 +1,38 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/kiranshivaraju/loghunter/internal/api/response"
+	"github.com/kiranshivaraju/loghunter/pkg/models"
+)
+
+// WatcherStatus holds the watcher state for the API response.
+type WatcherStatus struct {
+	Enabled         bool                     `json:"enabled"`
+	Running         bool                     `json:"running"`
+	LastPollAt      *time.Time               `json:"last_poll_at,omitempty"`
+	NextPollAt      *time.Time               `json:"next_poll_at,omitempty"`
+	ServicesWatched []string                 `json:"services_watched"`
+	RecentFindings  []*models.WatcherFinding `json:"recent_findings"`
+}
+
+// WatcherStatusProvider returns the current watcher status.
+type WatcherStatusProvider interface {
+	WatcherStatus(ctx context.Context) (WatcherStatus, error)
+}
+
+// NewWatcherStatusHandler returns an http.HandlerFunc for GET /api/v1/watcher/status.
+func NewWatcherStatusHandler(provider WatcherStatusProvider) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		status, err := provider.WatcherStatus(r.Context())
+		if err != nil {
+			code, errCode, msg := mapError(err)
+			response.Error(w, code, errCode, msg, nil)
+			return
+		}
+		response.JSON(w, status)
+	}
+}

--- a/internal/api/handler/watcher_test.go
+++ b/internal/api/handler/watcher_test.go
@@ -1,0 +1,137 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/kiranshivaraju/loghunter/pkg/models"
+)
+
+type mockWatcherStatusProvider struct {
+	fn func(ctx context.Context) (WatcherStatus, error)
+}
+
+func (m *mockWatcherStatusProvider) WatcherStatus(ctx context.Context) (WatcherStatus, error) {
+	return m.fn(ctx)
+}
+
+func TestWatcherStatusHandler_Success(t *testing.T) {
+	now := time.Now().UTC()
+	next := now.Add(60 * time.Second)
+
+	provider := &mockWatcherStatusProvider{
+		fn: func(_ context.Context) (WatcherStatus, error) {
+			return WatcherStatus{
+				Enabled:         true,
+				Running:         true,
+				LastPollAt:      &now,
+				NextPollAt:      &next,
+				ServicesWatched: []string{"auth-service", "payment-service"},
+				RecentFindings: []*models.WatcherFinding{
+					{
+						ID:                uuid.New(),
+						ClusterID:         uuid.New(),
+						Service:           "auth-service",
+						Kind:              "new",
+						CurrentCount:      5,
+						PrevCount:         0,
+						AnalysisTriggered: true,
+						DetectedAt:        now,
+					},
+				},
+			}, nil
+		},
+	}
+
+	handler := NewWatcherStatusHandler(provider)
+	req := httptest.NewRequest("GET", "/api/v1/watcher/status", nil)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to parse JSON: %v", err)
+	}
+
+	data, ok := resp["data"].(map[string]any)
+	if !ok {
+		t.Fatal("expected data envelope")
+	}
+
+	if data["enabled"] != true {
+		t.Errorf("expected enabled=true, got %v", data["enabled"])
+	}
+	if data["running"] != true {
+		t.Errorf("expected running=true, got %v", data["running"])
+	}
+
+	services, ok := data["services_watched"].([]any)
+	if !ok || len(services) != 2 {
+		t.Errorf("expected 2 services, got %v", data["services_watched"])
+	}
+
+	findings, ok := data["recent_findings"].([]any)
+	if !ok || len(findings) != 1 {
+		t.Errorf("expected 1 finding, got %v", data["recent_findings"])
+	}
+}
+
+func TestWatcherStatusHandler_Disabled(t *testing.T) {
+	provider := &mockWatcherStatusProvider{
+		fn: func(_ context.Context) (WatcherStatus, error) {
+			return WatcherStatus{
+				Enabled:         false,
+				Running:         false,
+				ServicesWatched: []string{},
+				RecentFindings:  []*models.WatcherFinding{},
+			}, nil
+		},
+	}
+
+	handler := NewWatcherStatusHandler(provider)
+	req := httptest.NewRequest("GET", "/api/v1/watcher/status", nil)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	var resp map[string]any
+	json.NewDecoder(rr.Body).Decode(&resp)
+	data := resp["data"].(map[string]any)
+
+	if data["enabled"] != false {
+		t.Errorf("expected enabled=false")
+	}
+}
+
+func TestWatcherStatusHandler_Error(t *testing.T) {
+	provider := &mockWatcherStatusProvider{
+		fn: func(_ context.Context) (WatcherStatus, error) {
+			return WatcherStatus{}, errors.New("db connection failed")
+		},
+	}
+
+	handler := NewWatcherStatusHandler(provider)
+	req := httptest.NewRequest("GET", "/api/v1/watcher/status", nil)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", rr.Code)
+	}
+}

--- a/internal/api/middleware/middleware_test.go
+++ b/internal/api/middleware/middleware_test.go
@@ -65,6 +65,15 @@ func (m *mockStore) GetJob(_ context.Context, _ uuid.UUID, _ uuid.UUID) (*models
 func (m *mockStore) UpdateJobStatus(_ context.Context, _ uuid.UUID, _ string, _ ...store.JobUpdateOption) error {
 	return nil
 }
+func (m *mockStore) UpsertErrorClusterFull(_ context.Context, _ *models.ErrorCluster) (store.UpsertResult, error) {
+	return store.UpsertResult{}, nil
+}
+func (m *mockStore) CreateWatcherFinding(_ context.Context, _ *models.WatcherFinding) error {
+	return nil
+}
+func (m *mockStore) ListWatcherFindings(_ context.Context, _ uuid.UUID, _ int) ([]*models.WatcherFinding, error) {
+	return nil, nil
+}
 
 // --- Mock Cache ---
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -13,8 +13,9 @@ type Dependencies struct {
 	Auth      *mw.Auth
 	RateLimit *mw.RateLimit
 
-	HealthHandler   http.HandlerFunc
-	AnalyzeHandler  http.HandlerFunc
+	HealthHandler        http.HandlerFunc
+	WatcherStatusHandler http.HandlerFunc
+	AnalyzeHandler       http.HandlerFunc
 	PollJobHandler  http.HandlerFunc
 	ListClusters    http.HandlerFunc
 	GetCluster      http.HandlerFunc
@@ -40,6 +41,8 @@ func NewRouter(deps Dependencies) http.Handler {
 	r.Group(func(r chi.Router) {
 		r.Use(deps.Auth.Authenticate)
 		r.Use(deps.RateLimit.Limit)
+
+		r.Get("/api/v1/watcher/status", orNotImplemented(deps.WatcherStatusHandler))
 
 		r.Post("/api/v1/analyze", orNotImplemented(deps.AnalyzeHandler))
 		r.Get("/api/v1/analyze/{jobID}", orNotImplemented(deps.PollJobHandler))

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -63,6 +63,15 @@ func (s *stubStore) GetJob(_ context.Context, _ uuid.UUID, _ uuid.UUID) (*models
 func (s *stubStore) UpdateJobStatus(_ context.Context, _ uuid.UUID, _ string, _ ...store.JobUpdateOption) error {
 	return nil
 }
+func (s *stubStore) UpsertErrorClusterFull(_ context.Context, _ *models.ErrorCluster) (store.UpsertResult, error) {
+	return store.UpsertResult{}, nil
+}
+func (s *stubStore) CreateWatcherFinding(_ context.Context, _ *models.WatcherFinding) error {
+	return nil
+}
+func (s *stubStore) ListWatcherFindings(_ context.Context, _ uuid.UUID, _ int) ([]*models.WatcherFinding, error) {
+	return nil, nil
+}
 
 // --- stub cache ---
 

--- a/internal/cache/keys.go
+++ b/internal/cache/keys.go
@@ -21,3 +21,7 @@ func RateLimitKey(keyPrefix string) string {
 func SearchResultKey(tenantID uuid.UUID, filterHash string) string {
 	return fmt.Sprintf("loki:search:%s:%s", tenantID, filterHash)
 }
+
+func WatcherAnalysisGuardKey(tenantID uuid.UUID, clusterID uuid.UUID) string {
+	return fmt.Sprintf("watcher:analyzed:%s:%s", tenantID, clusterID)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,19 @@ type Config struct {
 	Redis    RedisConfig
 	Loki     LokiConfig
 	AI       AIConfig
+	Watcher  WatcherConfig
+}
+
+type WatcherConfig struct {
+	Enabled        bool
+	Interval       time.Duration
+	LookbackWindow time.Duration
+	Services       []string
+	Namespace      string
+	AutoAnalyze    bool
+	SpikeThreshold float64
+	MaxServices    int
+	LogsLimit      int
 }
 
 type ServerConfig struct {
@@ -121,6 +134,17 @@ func Load() (*Config, error) {
 				Model:  envString("ANTHROPIC_MODEL", "claude-sonnet-4-5-20250929"),
 			},
 		},
+		Watcher: WatcherConfig{
+			Enabled:        envBool("WATCHER_ENABLED", false),
+			Interval:       envDurationSecs("WATCHER_INTERVAL_SECS", 60*time.Second),
+			LookbackWindow: envDurationSecs("WATCHER_LOOKBACK_SECS", 120*time.Second),
+			Services:       envStringSlice("WATCHER_SERVICES"),
+			Namespace:      envString("WATCHER_NAMESPACE", "default"),
+			AutoAnalyze:    envBool("WATCHER_AUTO_ANALYZE", true),
+			SpikeThreshold: envFloat("WATCHER_SPIKE_THRESHOLD", 3.0),
+			MaxServices:    envInt("WATCHER_MAX_SERVICES", 50),
+			LogsLimit:      envInt("WATCHER_LOGS_LIMIT", 2000),
+		},
 	}
 
 	if err := cfg.validate(); err != nil {
@@ -204,4 +228,42 @@ func envDurationSecs(key string, defaultVal time.Duration) time.Duration {
 		return defaultVal
 	}
 	return time.Duration(secs) * time.Second
+}
+
+func envBool(key string, defaultVal bool) bool {
+	v := os.Getenv(key)
+	if v == "" {
+		return defaultVal
+	}
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		return defaultVal
+	}
+	return b
+}
+
+func envFloat(key string, defaultVal float64) float64 {
+	v := os.Getenv(key)
+	if v == "" {
+		return defaultVal
+	}
+	f, err := strconv.ParseFloat(v, 64)
+	if err != nil {
+		return defaultVal
+	}
+	return f
+}
+
+func envStringSlice(key string) []string {
+	v := os.Getenv(key)
+	if v == "" {
+		return nil
+	}
+	var result []string
+	for _, s := range strings.Split(v, ",") {
+		if t := strings.TrimSpace(s); t != "" {
+			result = append(result, t)
+		}
+	}
+	return result
 }

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -128,7 +128,17 @@ func (s *PostgresStore) RevokeAPIKey(ctx context.Context, id uuid.UUID, tenantID
 // --- Error Clusters ---
 
 func (s *PostgresStore) UpsertErrorCluster(ctx context.Context, cluster *models.ErrorCluster) (*models.ErrorCluster, error) {
+	r, err := s.UpsertErrorClusterFull(ctx, cluster)
+	if err != nil {
+		return nil, err
+	}
+	return r.Cluster, nil
+}
+
+func (s *PostgresStore) UpsertErrorClusterFull(ctx context.Context, cluster *models.ErrorCluster) (UpsertResult, error) {
 	var result models.ErrorCluster
+	var isNew bool
+	var prevCount int
 	err := s.pool.QueryRow(ctx,
 		`INSERT INTO error_clusters (id, tenant_id, service, namespace, fingerprint, level, first_seen_at, last_seen_at, count, sample_message, created_at, updated_at)
 		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
@@ -136,17 +146,19 @@ func (s *PostgresStore) UpsertErrorCluster(ctx context.Context, cluster *models.
 		   count = error_clusters.count + EXCLUDED.count,
 		   last_seen_at = GREATEST(error_clusters.last_seen_at, EXCLUDED.last_seen_at),
 		   updated_at = NOW()
-		 RETURNING id, tenant_id, service, namespace, fingerprint, level, first_seen_at, last_seen_at, count, sample_message, created_at, updated_at`,
+		 RETURNING id, tenant_id, service, namespace, fingerprint, level, first_seen_at, last_seen_at, count, sample_message, created_at, updated_at,
+		   (xmax = 0)::boolean,
+		   CASE WHEN (xmax = 0) THEN 0 ELSE count - EXCLUDED.count END`,
 		cluster.ID, cluster.TenantID, cluster.Service, cluster.Namespace, cluster.Fingerprint,
 		cluster.Level, cluster.FirstSeenAt, cluster.LastSeenAt, cluster.Count, cluster.SampleMessage,
 		cluster.CreatedAt, cluster.UpdatedAt,
 	).Scan(&result.ID, &result.TenantID, &result.Service, &result.Namespace, &result.Fingerprint,
 		&result.Level, &result.FirstSeenAt, &result.LastSeenAt, &result.Count, &result.SampleMessage,
-		&result.CreatedAt, &result.UpdatedAt)
+		&result.CreatedAt, &result.UpdatedAt, &isNew, &prevCount)
 	if err != nil {
-		return nil, fmt.Errorf("upsert error cluster: %w", err)
+		return UpsertResult{}, fmt.Errorf("upsert error cluster: %w", err)
 	}
-	return &result, nil
+	return UpsertResult{Cluster: &result, IsNew: isNew, PrevCount: prevCount}, nil
 }
 
 func (s *PostgresStore) ListErrorClusters(ctx context.Context, filter ClusterFilter) ([]*models.ErrorCluster, int, error) {
@@ -411,6 +423,46 @@ func (s *PostgresStore) UpdateJobStatus(ctx context.Context, id uuid.UUID, statu
 		return fmt.Errorf("update job status: %w", err)
 	}
 	return nil
+}
+
+// --- Watcher Findings ---
+
+func (s *PostgresStore) CreateWatcherFinding(ctx context.Context, finding *models.WatcherFinding) error {
+	_, err := s.pool.Exec(ctx,
+		`INSERT INTO watcher_findings (id, tenant_id, cluster_id, service, namespace, kind, current_count, prev_count, analysis_triggered, job_id, detected_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+		finding.ID, finding.TenantID, finding.ClusterID, finding.Service, finding.Namespace,
+		finding.Kind, finding.CurrentCount, finding.PrevCount, finding.AnalysisTriggered,
+		finding.JobID, finding.DetectedAt)
+	if err != nil {
+		return fmt.Errorf("create watcher finding: %w", err)
+	}
+	return nil
+}
+
+func (s *PostgresStore) ListWatcherFindings(ctx context.Context, tenantID uuid.UUID, limit int) ([]*models.WatcherFinding, error) {
+	if limit <= 0 {
+		limit = 20
+	}
+	rows, err := s.pool.Query(ctx,
+		`SELECT id, tenant_id, cluster_id, service, namespace, kind, current_count, prev_count, analysis_triggered, job_id, detected_at
+		 FROM watcher_findings WHERE tenant_id = $1 ORDER BY detected_at DESC LIMIT $2`, tenantID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("list watcher findings: %w", err)
+	}
+	defer rows.Close()
+
+	var findings []*models.WatcherFinding
+	for rows.Next() {
+		var f models.WatcherFinding
+		if err := rows.Scan(&f.ID, &f.TenantID, &f.ClusterID, &f.Service, &f.Namespace,
+			&f.Kind, &f.CurrentCount, &f.PrevCount, &f.AnalysisTriggered,
+			&f.JobID, &f.DetectedAt); err != nil {
+			return nil, fmt.Errorf("scan watcher finding: %w", err)
+		}
+		findings = append(findings, &f)
+	}
+	return findings, rows.Err()
 }
 
 // isDuplicateKeyError checks if a pgx error is a unique constraint violation.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -24,6 +24,7 @@ type Store interface {
 	RevokeAPIKey(ctx context.Context, id uuid.UUID, tenantID uuid.UUID) error
 
 	UpsertErrorCluster(ctx context.Context, cluster *models.ErrorCluster) (*models.ErrorCluster, error)
+	UpsertErrorClusterFull(ctx context.Context, cluster *models.ErrorCluster) (UpsertResult, error)
 	ListErrorClusters(ctx context.Context, filter ClusterFilter) ([]*models.ErrorCluster, int, error)
 	GetErrorCluster(ctx context.Context, id uuid.UUID, tenantID uuid.UUID) (*models.ErrorCluster, error)
 	GetClustersByFingerprints(ctx context.Context, tenantID uuid.UUID, fingerprints []string) ([]*models.ErrorCluster, error)
@@ -35,6 +36,16 @@ type Store interface {
 	CreateJob(ctx context.Context, job *models.Job) error
 	GetJob(ctx context.Context, id uuid.UUID, tenantID uuid.UUID) (*models.Job, error)
 	UpdateJobStatus(ctx context.Context, id uuid.UUID, status string, opts ...JobUpdateOption) error
+
+	CreateWatcherFinding(ctx context.Context, finding *models.WatcherFinding) error
+	ListWatcherFindings(ctx context.Context, tenantID uuid.UUID, limit int) ([]*models.WatcherFinding, error)
+}
+
+// UpsertResult is returned by UpsertErrorClusterFull with metadata about the upsert operation.
+type UpsertResult struct {
+	Cluster   *models.ErrorCluster
+	IsNew     bool // true when the row was INSERTed (not updated)
+	PrevCount int  // count before this upsert (0 when IsNew)
 }
 
 type ClusterFilter struct {

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -1,0 +1,344 @@
+package watcher
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/kiranshivaraju/loghunter/internal/analysis"
+	"github.com/kiranshivaraju/loghunter/internal/cache"
+	"github.com/kiranshivaraju/loghunter/internal/config"
+	"github.com/kiranshivaraju/loghunter/internal/loki"
+	"github.com/kiranshivaraju/loghunter/internal/store"
+	"github.com/kiranshivaraju/loghunter/pkg/logql"
+	"github.com/kiranshivaraju/loghunter/pkg/models"
+)
+
+const analysisGuardTTL = 6 * time.Hour
+
+// WatcherStore is the store subset required by the Watcher.
+type WatcherStore interface {
+	UpsertErrorClusterFull(ctx context.Context, cluster *models.ErrorCluster) (store.UpsertResult, error)
+	CreateWatcherFinding(ctx context.Context, finding *models.WatcherFinding) error
+	ListWatcherFindings(ctx context.Context, tenantID uuid.UUID, limit int) ([]*models.WatcherFinding, error)
+}
+
+// Analyzer triggers AI analysis on an error cluster.
+type Analyzer interface {
+	TriggerAnalysis(ctx context.Context, cluster *models.ErrorCluster) (*models.Job, error)
+}
+
+// LokiDiscoverer is the Loki client subset required by the Watcher.
+type LokiDiscoverer interface {
+	LabelValues(ctx context.Context, label string) ([]string, error)
+	QueryRange(ctx context.Context, req loki.QueryRangeRequest) ([]models.LogLine, error)
+}
+
+// AnalysisGuardCache is the cache subset for the analysis dedup guard.
+type AnalysisGuardCache interface {
+	Get(ctx context.Context, key string) ([]byte, bool, error)
+	Set(ctx context.Context, key string, value []byte, ttl time.Duration) error
+}
+
+// Notifier is called after a finding is detected.
+// Implementations must be safe for concurrent use and must not block.
+type Notifier interface {
+	Notify(ctx context.Context, finding Finding) error
+}
+
+// NoopNotifier is the default notifier that does nothing.
+type NoopNotifier struct{}
+
+func (NoopNotifier) Notify(_ context.Context, _ Finding) error { return nil }
+
+// Finding is the payload passed to notifiers.
+type Finding struct {
+	Cluster   *models.ErrorCluster
+	Kind      string
+	PrevCount int
+	JobID     *uuid.UUID
+	DetectedAt time.Time
+}
+
+// WatcherStatus is returned by the Status method for the API.
+type WatcherStatus struct {
+	Enabled         bool               `json:"enabled"`
+	Running         bool               `json:"running"`
+	LastPollAt      *time.Time         `json:"last_poll_at,omitempty"`
+	NextPollAt      *time.Time         `json:"next_poll_at,omitempty"`
+	ServicesWatched []string           `json:"services_watched"`
+	RecentFindings  []*models.WatcherFinding `json:"recent_findings"`
+}
+
+// Option configures a Watcher.
+type Option func(*Watcher)
+
+// WithNotifier sets a custom notifier.
+func WithNotifier(n Notifier) Option {
+	return func(w *Watcher) { w.notifier = n }
+}
+
+// Watcher continuously monitors Loki for error/warning logs and auto-triggers analysis.
+type Watcher struct {
+	cfg      config.WatcherConfig
+	loki     LokiDiscoverer
+	store    WatcherStore
+	analyzer Analyzer
+	cache    AnalysisGuardCache
+	notifier Notifier
+	tenant   *models.Tenant
+
+	mu              sync.RWMutex
+	running         bool
+	lastPollAt      *time.Time
+	nextPollAt      *time.Time
+	servicesWatched []string
+}
+
+// New creates a Watcher with the given dependencies.
+func New(cfg config.WatcherConfig, loki LokiDiscoverer, st WatcherStore, analyzer Analyzer, ca AnalysisGuardCache, tenant *models.Tenant, opts ...Option) *Watcher {
+	w := &Watcher{
+		cfg:      cfg,
+		loki:     loki,
+		store:    st,
+		analyzer: analyzer,
+		cache:    ca,
+		notifier: NoopNotifier{},
+		tenant:   tenant,
+	}
+	for _, opt := range opts {
+		opt(w)
+	}
+	return w
+}
+
+// Run starts the watcher loop. It blocks until ctx is cancelled.
+// If the watcher is disabled via config, it returns immediately.
+func (w *Watcher) Run(ctx context.Context) {
+	if !w.cfg.Enabled {
+		slog.Info("watcher disabled, skipping")
+		return
+	}
+
+	w.mu.Lock()
+	w.running = true
+	w.mu.Unlock()
+	defer func() {
+		w.mu.Lock()
+		w.running = false
+		w.mu.Unlock()
+	}()
+
+	slog.Info("watcher started", "interval", w.cfg.Interval)
+
+	// Run immediately on start
+	w.poll(ctx)
+
+	ticker := time.NewTicker(w.cfg.Interval)
+	defer ticker.Stop()
+
+	for {
+		next := time.Now().Add(w.cfg.Interval)
+		w.mu.Lock()
+		w.nextPollAt = &next
+		w.mu.Unlock()
+
+		select {
+		case <-ctx.Done():
+			slog.Info("watcher shutting down")
+			return
+		case <-ticker.C:
+			w.poll(ctx)
+		}
+	}
+}
+
+// Status returns the current watcher state for the API.
+func (w *Watcher) Status(ctx context.Context) (WatcherStatus, error) {
+	w.mu.RLock()
+	status := WatcherStatus{
+		Enabled:         w.cfg.Enabled,
+		Running:         w.running,
+		LastPollAt:      w.lastPollAt,
+		NextPollAt:      w.nextPollAt,
+		ServicesWatched: w.servicesWatched,
+	}
+	w.mu.RUnlock()
+
+	if status.ServicesWatched == nil {
+		status.ServicesWatched = []string{}
+	}
+
+	findings, err := w.store.ListWatcherFindings(ctx, w.tenant.ID, 20)
+	if err != nil {
+		return status, err
+	}
+	status.RecentFindings = findings
+	if status.RecentFindings == nil {
+		status.RecentFindings = []*models.WatcherFinding{}
+	}
+
+	return status, nil
+}
+
+func (w *Watcher) poll(ctx context.Context) {
+	now := time.Now().UTC()
+	w.mu.Lock()
+	w.lastPollAt = &now
+	w.mu.Unlock()
+
+	services, err := w.resolveServices(ctx)
+	if err != nil {
+		slog.Error("watcher: service discovery failed", "error", err)
+		return
+	}
+	w.mu.Lock()
+	w.servicesWatched = services
+	w.mu.Unlock()
+
+	end := now
+	start := now.Add(-w.cfg.LookbackWindow)
+
+	for _, svc := range services {
+		if ctx.Err() != nil {
+			return
+		}
+		w.pollService(ctx, svc, start, end)
+	}
+}
+
+func (w *Watcher) resolveServices(ctx context.Context) ([]string, error) {
+	if len(w.cfg.Services) > 0 {
+		return w.cfg.Services, nil
+	}
+
+	values, err := w.loki.LabelValues(ctx, "service")
+	if err != nil {
+		return nil, err
+	}
+
+	if len(values) > w.cfg.MaxServices {
+		slog.Warn("watcher: discovered more services than MaxServices cap, truncating",
+			"discovered", len(values), "cap", w.cfg.MaxServices)
+		values = values[:w.cfg.MaxServices]
+	}
+
+	return values, nil
+}
+
+func (w *Watcher) pollService(ctx context.Context, service string, start, end time.Time) {
+	qb := logql.QueryBuilder{}
+	query := qb.BuildDetectionQuery(logql.DetectionParams{
+		Service:   service,
+		Namespace: w.cfg.Namespace,
+	})
+
+	lines, err := w.loki.QueryRange(ctx, loki.QueryRangeRequest{
+		Query: query,
+		Start: start,
+		End:   end,
+		Limit: w.cfg.LogsLimit,
+	})
+	if err != nil {
+		slog.Warn("watcher: loki query failed", "service", service, "error", err)
+		return
+	}
+	if len(lines) == 0 {
+		return
+	}
+
+	clusters := analysis.Cluster(lines, service, w.cfg.Namespace)
+
+	for i := range clusters {
+		clusters[i].TenantID = w.tenant.ID
+		w.handleCluster(ctx, &clusters[i])
+	}
+}
+
+func (w *Watcher) handleCluster(ctx context.Context, c *models.ErrorCluster) {
+	result, err := w.store.UpsertErrorClusterFull(ctx, c)
+	if err != nil {
+		slog.Error("watcher: upsert failed", "fingerprint", c.Fingerprint, "error", err)
+		return
+	}
+
+	kind := w.classifyFinding(result)
+	if kind == "" {
+		return
+	}
+
+	var jobID *uuid.UUID
+	triggered := false
+	if w.cfg.AutoAnalyze && !w.isAnalysisGuarded(ctx, result.Cluster.ID) {
+		job, err := w.analyzer.TriggerAnalysis(ctx, result.Cluster)
+		if err != nil {
+			slog.Warn("watcher: auto-analysis trigger failed", "cluster_id", result.Cluster.ID, "error", err)
+		} else {
+			triggered = true
+			jobID = &job.ID
+			w.setAnalysisGuard(ctx, result.Cluster.ID)
+		}
+	}
+
+	slog.Info("watcher: finding detected",
+		"kind", kind,
+		"service", c.Service,
+		"cluster_id", result.Cluster.ID,
+		"count", result.Cluster.Count,
+		"prev_count", result.PrevCount,
+		"analysis_triggered", triggered,
+	)
+
+	w.recordFinding(ctx, result.Cluster, kind, result.PrevCount, triggered, jobID)
+
+	_ = w.notifier.Notify(ctx, Finding{
+		Cluster:    result.Cluster,
+		Kind:       kind,
+		PrevCount:  result.PrevCount,
+		JobID:      jobID,
+		DetectedAt: time.Now().UTC(),
+	})
+}
+
+func (w *Watcher) classifyFinding(r store.UpsertResult) string {
+	if r.IsNew {
+		return "new"
+	}
+	if r.PrevCount > 0 {
+		ratio := float64(r.Cluster.Count) / float64(r.PrevCount)
+		if ratio >= w.cfg.SpikeThreshold {
+			return "spike"
+		}
+	}
+	return ""
+}
+
+func (w *Watcher) isAnalysisGuarded(ctx context.Context, clusterID uuid.UUID) bool {
+	_, found, _ := w.cache.Get(ctx, cache.WatcherAnalysisGuardKey(w.tenant.ID, clusterID))
+	return found
+}
+
+func (w *Watcher) setAnalysisGuard(ctx context.Context, clusterID uuid.UUID) {
+	_ = w.cache.Set(ctx, cache.WatcherAnalysisGuardKey(w.tenant.ID, clusterID), []byte("1"), analysisGuardTTL)
+}
+
+func (w *Watcher) recordFinding(ctx context.Context, cluster *models.ErrorCluster, kind string, prevCount int, triggered bool, jobID *uuid.UUID) {
+	finding := &models.WatcherFinding{
+		ID:                uuid.New(),
+		TenantID:          w.tenant.ID,
+		ClusterID:         cluster.ID,
+		Service:           cluster.Service,
+		Namespace:         cluster.Namespace,
+		Kind:              kind,
+		CurrentCount:      cluster.Count,
+		PrevCount:         prevCount,
+		AnalysisTriggered: triggered,
+		JobID:             jobID,
+		DetectedAt:        time.Now().UTC(),
+	}
+	if err := w.store.CreateWatcherFinding(ctx, finding); err != nil {
+		slog.Error("watcher: failed to record finding", "error", err)
+	}
+}

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -1,0 +1,498 @@
+package watcher
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/kiranshivaraju/loghunter/internal/config"
+	"github.com/kiranshivaraju/loghunter/internal/loki"
+	"github.com/kiranshivaraju/loghunter/internal/store"
+	"github.com/kiranshivaraju/loghunter/pkg/models"
+)
+
+// --- mocks ---
+
+type mockLoki struct {
+	labelValues func(ctx context.Context, label string) ([]string, error)
+	queryRange  func(ctx context.Context, req loki.QueryRangeRequest) ([]models.LogLine, error)
+}
+
+func (m *mockLoki) LabelValues(ctx context.Context, label string) ([]string, error) {
+	if m.labelValues != nil {
+		return m.labelValues(ctx, label)
+	}
+	return nil, nil
+}
+
+func (m *mockLoki) QueryRange(ctx context.Context, req loki.QueryRangeRequest) ([]models.LogLine, error) {
+	if m.queryRange != nil {
+		return m.queryRange(ctx, req)
+	}
+	return nil, nil
+}
+
+type mockStore struct {
+	mu                    sync.Mutex
+	upsertFull            func(ctx context.Context, cluster *models.ErrorCluster) (store.UpsertResult, error)
+	createFinding         func(ctx context.Context, finding *models.WatcherFinding) error
+	listFindings          func(ctx context.Context, tenantID uuid.UUID, limit int) ([]*models.WatcherFinding, error)
+	createFindingCalls    int
+}
+
+func (m *mockStore) UpsertErrorClusterFull(ctx context.Context, cluster *models.ErrorCluster) (store.UpsertResult, error) {
+	if m.upsertFull != nil {
+		return m.upsertFull(ctx, cluster)
+	}
+	return store.UpsertResult{Cluster: cluster, IsNew: true}, nil
+}
+
+func (m *mockStore) CreateWatcherFinding(ctx context.Context, finding *models.WatcherFinding) error {
+	m.mu.Lock()
+	m.createFindingCalls++
+	m.mu.Unlock()
+	if m.createFinding != nil {
+		return m.createFinding(ctx, finding)
+	}
+	return nil
+}
+
+func (m *mockStore) ListWatcherFindings(ctx context.Context, tenantID uuid.UUID, limit int) ([]*models.WatcherFinding, error) {
+	if m.listFindings != nil {
+		return m.listFindings(ctx, tenantID, limit)
+	}
+	return nil, nil
+}
+
+type mockAnalyzer struct {
+	mu    sync.Mutex
+	calls int
+	fn    func(ctx context.Context, cluster *models.ErrorCluster) (*models.Job, error)
+}
+
+func (m *mockAnalyzer) TriggerAnalysis(ctx context.Context, cluster *models.ErrorCluster) (*models.Job, error) {
+	m.mu.Lock()
+	m.calls++
+	m.mu.Unlock()
+	if m.fn != nil {
+		return m.fn(ctx, cluster)
+	}
+	return &models.Job{ID: uuid.New()}, nil
+}
+
+type mockCache struct {
+	mu   sync.Mutex
+	data map[string][]byte
+}
+
+func newMockCache() *mockCache {
+	return &mockCache{data: make(map[string][]byte)}
+}
+
+func (m *mockCache) Get(_ context.Context, key string) ([]byte, bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	v, ok := m.data[key]
+	return v, ok, nil
+}
+
+func (m *mockCache) Set(_ context.Context, key string, value []byte, _ time.Duration) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.data[key] = value
+	return nil
+}
+
+type mockNotifier struct {
+	mu    sync.Mutex
+	calls []Finding
+}
+
+func (m *mockNotifier) Notify(_ context.Context, f Finding) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls = append(m.calls, f)
+	return nil
+}
+
+// --- helpers ---
+
+func testTenant() *models.Tenant {
+	return &models.Tenant{
+		ID:        uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+		Name:      "default",
+		LokiOrgID: "default",
+	}
+}
+
+func testConfig() config.WatcherConfig {
+	return config.WatcherConfig{
+		Enabled:        true,
+		Interval:       50 * time.Millisecond,
+		LookbackWindow: 2 * time.Minute,
+		Namespace:      "default",
+		AutoAnalyze:    true,
+		SpikeThreshold: 3.0,
+		MaxServices:    50,
+		LogsLimit:      2000,
+	}
+}
+
+func errorLogLines(service string, count int) []models.LogLine {
+	lines := make([]models.LogLine, count)
+	for i := range lines {
+		lines[i] = models.LogLine{
+			Timestamp: time.Now().UTC(),
+			Message:   "NullPointerException at com.example.Service.process(Service.java:42)",
+			Level:     "ERROR",
+			Labels:    map[string]string{"service": service},
+		}
+	}
+	return lines
+}
+
+// --- tests ---
+
+func TestWatcherDisabled(t *testing.T) {
+	cfg := testConfig()
+	cfg.Enabled = false
+
+	ml := &mockLoki{}
+	w := New(cfg, ml, &mockStore{}, &mockAnalyzer{}, newMockCache(), testTenant())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	w.Run(ctx)
+
+	// Should return immediately without calling any deps
+	if ml.labelValues != nil || ml.queryRange != nil {
+		t.Error("expected no loki calls when watcher is disabled")
+	}
+}
+
+func TestPollDetectsNewClusters(t *testing.T) {
+	cfg := testConfig()
+	cfg.Services = []string{"auth-service"}
+
+	ml := &mockLoki{
+		queryRange: func(_ context.Context, _ loki.QueryRangeRequest) ([]models.LogLine, error) {
+			return errorLogLines("auth-service", 5), nil
+		},
+	}
+
+	clusterID := uuid.New()
+	ms := &mockStore{
+		upsertFull: func(_ context.Context, c *models.ErrorCluster) (store.UpsertResult, error) {
+			c.ID = clusterID
+			return store.UpsertResult{Cluster: c, IsNew: true, PrevCount: 0}, nil
+		},
+	}
+
+	ma := &mockAnalyzer{}
+	mc := newMockCache()
+
+	w := New(cfg, ml, ms, ma, mc, testTenant())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	w.Run(ctx)
+
+	ma.mu.Lock()
+	calls := ma.calls
+	ma.mu.Unlock()
+
+	if calls == 0 {
+		t.Error("expected TriggerAnalysis to be called for new cluster")
+	}
+
+	ms.mu.Lock()
+	findingCalls := ms.createFindingCalls
+	ms.mu.Unlock()
+
+	if findingCalls == 0 {
+		t.Error("expected finding to be recorded")
+	}
+}
+
+func TestSpikeDetection(t *testing.T) {
+	tests := []struct {
+		name      string
+		prevCount int
+		newCount  int
+		threshold float64
+		want      string
+	}{
+		{"new cluster", 0, 5, 3.0, "new"},
+		{"spike 3x", 10, 30, 3.0, "spike"},
+		{"spike above threshold", 10, 35, 3.0, "spike"},
+		{"no spike below threshold", 10, 25, 3.0, ""},
+		{"no spike equal", 10, 10, 3.0, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := testConfig()
+			cfg.SpikeThreshold = tt.threshold
+
+			w := New(cfg, &mockLoki{}, &mockStore{}, &mockAnalyzer{}, newMockCache(), testTenant())
+
+			result := store.UpsertResult{
+				Cluster:   &models.ErrorCluster{Count: tt.newCount},
+				IsNew:     tt.prevCount == 0 && tt.name == "new cluster",
+				PrevCount: tt.prevCount,
+			}
+
+			got := w.classifyFinding(result)
+			if got != tt.want {
+				t.Errorf("classifyFinding() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAnalysisGuardPreventsRepeat(t *testing.T) {
+	cfg := testConfig()
+	cfg.Services = []string{"api-gateway"}
+
+	ml := &mockLoki{
+		queryRange: func(_ context.Context, _ loki.QueryRangeRequest) ([]models.LogLine, error) {
+			return errorLogLines("api-gateway", 3), nil
+		},
+	}
+
+	clusterID := uuid.New()
+	ms := &mockStore{
+		upsertFull: func(_ context.Context, c *models.ErrorCluster) (store.UpsertResult, error) {
+			c.ID = clusterID
+			return store.UpsertResult{Cluster: c, IsNew: true, PrevCount: 0}, nil
+		},
+	}
+
+	ma := &mockAnalyzer{}
+	mc := newMockCache()
+
+	w := New(cfg, ml, ms, ma, mc, testTenant())
+
+	// Run multiple polls — the guard should prevent duplicate analysis
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	w.Run(ctx)
+
+	ma.mu.Lock()
+	calls := ma.calls
+	ma.mu.Unlock()
+
+	// Should be called exactly once due to guard
+	if calls != 1 {
+		t.Errorf("expected TriggerAnalysis to be called exactly 1 time, got %d", calls)
+	}
+}
+
+func TestMaxServicesCapEnforced(t *testing.T) {
+	cfg := testConfig()
+	cfg.MaxServices = 3
+
+	var discoveredCount int
+	many := make([]string, 10)
+	for i := range many {
+		many[i] = "svc-" + uuid.New().String()[:8]
+	}
+
+	ml := &mockLoki{
+		labelValues: func(_ context.Context, _ string) ([]string, error) {
+			return many, nil
+		},
+		queryRange: func(_ context.Context, req loki.QueryRangeRequest) ([]models.LogLine, error) {
+			discoveredCount++
+			return nil, nil // no logs
+		},
+	}
+
+	w := New(cfg, ml, &mockStore{}, &mockAnalyzer{}, newMockCache(), testTenant())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	w.Run(ctx)
+
+	// Should have polled at most MaxServices services per poll cycle
+	if discoveredCount > cfg.MaxServices*5 { // allow a few poll cycles
+		t.Errorf("expected at most %d services polled per cycle, but total queryRange calls = %d", cfg.MaxServices, discoveredCount)
+	}
+}
+
+func TestGracefulShutdown(t *testing.T) {
+	cfg := testConfig()
+	cfg.Services = []string{"slow-service"}
+	cfg.Interval = 10 * time.Second // long interval to ensure we test shutdown
+
+	ml := &mockLoki{
+		queryRange: func(ctx context.Context, _ loki.QueryRangeRequest) ([]models.LogLine, error) {
+			// Simulate a slow query
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(5 * time.Millisecond):
+				return nil, nil
+			}
+		},
+	}
+
+	w := New(cfg, ml, &mockStore{}, &mockAnalyzer{}, newMockCache(), testTenant())
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		w.Run(ctx)
+		close(done)
+	}()
+
+	// Let first poll run
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+		// success
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher did not shut down in time")
+	}
+}
+
+func TestStaticServiceListSkipsDiscovery(t *testing.T) {
+	cfg := testConfig()
+	cfg.Services = []string{"my-service"}
+
+	labelValuesCalled := false
+	ml := &mockLoki{
+		labelValues: func(_ context.Context, _ string) ([]string, error) {
+			labelValuesCalled = true
+			return nil, nil
+		},
+		queryRange: func(_ context.Context, _ loki.QueryRangeRequest) ([]models.LogLine, error) {
+			return nil, nil
+		},
+	}
+
+	w := New(cfg, ml, &mockStore{}, &mockAnalyzer{}, newMockCache(), testTenant())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	w.Run(ctx)
+
+	if labelValuesCalled {
+		t.Error("expected LabelValues to NOT be called when static services are configured")
+	}
+}
+
+func TestNotifierCalled(t *testing.T) {
+	cfg := testConfig()
+	cfg.Services = []string{"notify-svc"}
+
+	ml := &mockLoki{
+		queryRange: func(_ context.Context, _ loki.QueryRangeRequest) ([]models.LogLine, error) {
+			return errorLogLines("notify-svc", 2), nil
+		},
+	}
+
+	clusterID := uuid.New()
+	ms := &mockStore{
+		upsertFull: func(_ context.Context, c *models.ErrorCluster) (store.UpsertResult, error) {
+			c.ID = clusterID
+			return store.UpsertResult{Cluster: c, IsNew: true, PrevCount: 0}, nil
+		},
+	}
+
+	mn := &mockNotifier{}
+	w := New(cfg, ml, ms, &mockAnalyzer{}, newMockCache(), testTenant(), WithNotifier(mn))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	w.Run(ctx)
+
+	mn.mu.Lock()
+	calls := len(mn.calls)
+	mn.mu.Unlock()
+
+	if calls == 0 {
+		t.Error("expected notifier to be called for new cluster")
+	}
+}
+
+func TestStatusReturnsCorrectState(t *testing.T) {
+	cfg := testConfig()
+	cfg.Services = []string{"status-svc"}
+
+	ms := &mockStore{
+		listFindings: func(_ context.Context, _ uuid.UUID, _ int) ([]*models.WatcherFinding, error) {
+			return []*models.WatcherFinding{
+				{ID: uuid.New(), Kind: "new", Service: "status-svc"},
+			}, nil
+		},
+	}
+
+	w := New(cfg, &mockLoki{}, ms, &mockAnalyzer{}, newMockCache(), testTenant())
+
+	// Not running yet
+	status, err := w.Status(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !status.Enabled {
+		t.Error("expected enabled=true")
+	}
+	if status.Running {
+		t.Error("expected running=false before Run()")
+	}
+	if len(status.RecentFindings) != 1 {
+		t.Errorf("expected 1 finding, got %d", len(status.RecentFindings))
+	}
+}
+
+func TestAutoAnalyzeDisabled(t *testing.T) {
+	cfg := testConfig()
+	cfg.Services = []string{"no-analyze"}
+	cfg.AutoAnalyze = false
+
+	ml := &mockLoki{
+		queryRange: func(_ context.Context, _ loki.QueryRangeRequest) ([]models.LogLine, error) {
+			return errorLogLines("no-analyze", 3), nil
+		},
+	}
+
+	clusterID := uuid.New()
+	ms := &mockStore{
+		upsertFull: func(_ context.Context, c *models.ErrorCluster) (store.UpsertResult, error) {
+			c.ID = clusterID
+			return store.UpsertResult{Cluster: c, IsNew: true, PrevCount: 0}, nil
+		},
+	}
+
+	ma := &mockAnalyzer{}
+	w := New(cfg, ml, ms, ma, newMockCache(), testTenant())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	w.Run(ctx)
+
+	ma.mu.Lock()
+	calls := ma.calls
+	ma.mu.Unlock()
+
+	if calls != 0 {
+		t.Errorf("expected no analysis calls when AutoAnalyze is disabled, got %d", calls)
+	}
+
+	// But finding should still be recorded
+	ms.mu.Lock()
+	findingCalls := ms.createFindingCalls
+	ms.mu.Unlock()
+
+	if findingCalls == 0 {
+		t.Error("expected finding to be recorded even when auto-analyze is disabled")
+	}
+}

--- a/migrations/000008_add_watcher_findings.down.sql
+++ b/migrations/000008_add_watcher_findings.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS watcher_findings;

--- a/migrations/000008_add_watcher_findings.up.sql
+++ b/migrations/000008_add_watcher_findings.up.sql
@@ -1,0 +1,15 @@
+CREATE TABLE watcher_findings (
+    id                 UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id          UUID        NOT NULL REFERENCES tenants(id),
+    cluster_id         UUID        NOT NULL REFERENCES error_clusters(id),
+    service            VARCHAR(255) NOT NULL,
+    namespace          VARCHAR(255) NOT NULL,
+    kind               VARCHAR(16)  NOT NULL CHECK (kind IN ('new', 'spike')),
+    current_count      INTEGER      NOT NULL,
+    prev_count         INTEGER      NOT NULL DEFAULT 0,
+    analysis_triggered BOOLEAN      NOT NULL DEFAULT FALSE,
+    job_id             UUID,
+    detected_at        TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_watcher_findings_tenant_time ON watcher_findings(tenant_id, detected_at DESC);

--- a/pkg/models/watcher.go
+++ b/pkg/models/watcher.go
@@ -1,0 +1,22 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// WatcherFinding records a single detection event from the watcher background loop.
+type WatcherFinding struct {
+	ID                uuid.UUID  `json:"id"`
+	TenantID          uuid.UUID  `json:"tenant_id"`
+	ClusterID         uuid.UUID  `json:"cluster_id"`
+	Service           string     `json:"service"`
+	Namespace         string     `json:"namespace"`
+	Kind              string     `json:"kind"`
+	CurrentCount      int        `json:"current_count"`
+	PrevCount         int        `json:"prev_count"`
+	AnalysisTriggered bool       `json:"analysis_triggered"`
+	JobID             *uuid.UUID `json:"job_id,omitempty"`
+	DetectedAt        time.Time  `json:"detected_at"`
+}


### PR DESCRIPTION
## Summary

- Adds a background **Watcher** that continuously polls Loki for error/warn logs, clusters them by fingerprint, detects new and spiking error patterns, and auto-triggers AI root cause analysis
- New `GET /api/v1/watcher/status` endpoint exposes watcher state and recent findings
- New `watcher_findings` table (migration 008) for audit trail
- `UpsertErrorClusterFull` uses PostgreSQL `xmax` for zero-overhead insert-vs-update detection
- 9 new `WATCHER_*` env vars (opt-in via `WATCHER_ENABLED=true`)
- Pluggable `Notifier` interface for future Slack/webhook integration (Phase 3)
- 13 new tests (10 watcher + 3 handler), all existing tests pass

## How it works

Every 60 seconds (configurable):
1. Discovers services from Loki labels (or uses a static list)
2. Queries Loki for recent error/warn logs per service
3. Clusters identical errors by normalizing and fingerprinting log messages
4. Upserts clusters to Postgres — detects **new** clusters and **spikes** (3x+ count jump)
5. Auto-triggers AI analysis on findings (with a 6-hour Redis dedup guard)
6. Records findings to `watcher_findings` for the status API

## Test plan

- [x] `go test ./...` — all 21 packages pass
- [x] `go build ./cmd/server/` compiles cleanly
- [ ] Enable with `WATCHER_ENABLED=true`, seed logs, verify findings appear in `GET /api/v1/watcher/status`
- [ ] Verify auto-analysis jobs are triggered and produce results

🤖 Generated with [Claude Code](https://claude.com/claude-code)